### PR TITLE
Remove extra X-Forwarded-For header handling

### DIFF
--- a/4.1/templates/default.vcl.tpl
+++ b/4.1/templates/default.vcl.tpl
@@ -23,16 +23,6 @@ sub vcl_recv {
     # Protecting against the HTTPOXY CGI vulnerability.
     unset req.http.proxy;
 
-    # Add an X-Forwarded-For header with the client IP address.
-    if (req.restarts == 0) {
-        if (req.http.X-Forwarded-For) {
-            set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
-        }
-        else {
-            set req.http.X-Forwarded-For = client.ip;
-        }
-    }
-
     # Only allow PURGE requests from IP addresses in the 'purge' ACL.
     if (req.method == "PURGE") {
         if (!client.ip ~ purge) {


### PR DESCRIPTION
We need to remove the X-Forwarded-For header logic from vcl_recv cause it is already done in the Varnish itself. - see https://github.com/varnishcache/varnish-cache/blob/4.0/bin/varnishd/cache/cache_req_fsm.c#L724 and https://github.com/varnishcache/varnish-cache/blob/4.0/bin/varnishd/cache/cache_req_fsm.c#L753

So basically this logic runs twice: first in the Varnish core code, and then in the vcl_recv we have in default.vcl - this produces duplication of client.ip in the X-Forwarded-For header.

Example: X-Forwarded-For is not set when request comes to Varnish, client IP is 127.0.0.1
With current config Varnish will set `X-Forwarded-For: 127.0.0.1, 127.0.0.1`
With this PR fix - `X-Forwarded-For: 127.0.0.1`

Related issue: https://github.com/skilld-labs/skilld-varnish/pull/9