### PR TITLE
Allow adding a condition to switch to the secondary storage

### DIFF
--- a/4/templates/default.vcl.tpl
+++ b/4/templates/default.vcl.tpl
@@ -185,7 +185,7 @@ sub vcl_backend_response {
     # Allow items to remain in cache up to N hours past their cache expiration.
     set beresp.grace = {{ getenv "VARNISH_GRACE" "6h" }};
 
-    {{ if getenv "VARNISH_SECONDARY_STORAGE_CONDITION" and getenv "VARNISHD_SECONDARY_STORAGE" }}
+    {{ if and (getenv "VARNISH_SECONDARY_STORAGE_CONDITION") (getenv "VARNISHD_SECONDARY_STORAGE") }}
     # Switch to the secondary storage if needed
     if ({{ getenv "VARNISH_SECONDARY_STORAGE_CONDITION" }}) {
       set beresp.storage_hint = "secondary";

--- a/4/templates/default.vcl.tpl
+++ b/4/templates/default.vcl.tpl
@@ -185,9 +185,9 @@ sub vcl_backend_response {
     # Allow items to remain in cache up to N hours past their cache expiration.
     set beresp.grace = {{ getenv "VARNISH_GRACE" "6h" }};
 
-    {{ if getenv "VARNISH_STORAGE_CONDITION" }}
+    {{ if getenv "VARNISH_SECONDARY_STORAGE_CONDITION" and getenv "VARNISHD_SECONDARY_STORAGE" }}
     # Switch to the secondary storage if needed
-    if ({{ getenv "VARNISH_STORAGE_CONDITION" "false" }}) {
+    if ({{ getenv "VARNISH_SECONDARY_STORAGE_CONDITION" }}) {
       set beresp.storage_hint = "secondary";
       set beresp.http.x-varnish-storage = "secondary";
     }

--- a/4/templates/default.vcl.tpl
+++ b/4/templates/default.vcl.tpl
@@ -184,6 +184,14 @@ sub vcl_backend_response {
 
     # Allow items to remain in cache up to N hours past their cache expiration.
     set beresp.grace = {{ getenv "VARNISH_GRACE" "6h" }};
+
+    {{ if getenv "VARNISH_STORAGE_CONDITION" }}
+    # Switch to the secondary storage if needed
+    if ({{ getenv "VARNISH_STORAGE_CONDITION" "false" }}) {
+      set beresp.storage_hint = "secondary";
+      set beresp.http.x-varnish-storage = "secondary";
+    }
+    {{ end }}
 }
 
 sub vcl_pipe {

--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ Supported tags and respective `Dockerfile` links:
 
 See more at [wodby/varnish](https://github.com/wodby/varnish)
 
-| Variable                                | Default Value | Description |
-| --------------------------------------- | ------------- | ----------- |
-| `VARNISH_ALLOW_UNRESTRICTED_BAN`        |               |             |
-| `VARNISH_ALLOW_UNRESTRICTED_PURGE`      |               |             |
-| `VARNISH_ERRORS_TTL`                    | `10m`         |             |
-| `VARNISH_GRACE`                         | `6h`          |             |
-| `VARNISH_BACKEND_FIRST_BYTE_TIMEOUT`    | `300s`        |             |
-| `VARNISH_BACKEND_CONNECT_TIMEOUT`       | `5s`          |             |
-| `VARNISH_BACKEND_BETWEEN_BYTES_TIMEOUT` | `2s`          |             |
+| Variable                                | Default Value | Description       |
+| --------------------------------------- | ------------- | ----------------- |
+| `VARNISH_ALLOW_UNRESTRICTED_BAN`        |               |                   |
+| `VARNISH_ALLOW_UNRESTRICTED_PURGE`      |               |                   |
+| `VARNISH_ERRORS_TTL`                    | `10m`         |                   |
+| `VARNISH_GRACE`                         | `6h`          |                   |
+| `VARNISH_BACKEND_FIRST_BYTE_TIMEOUT`    | `300s`        |                   |
+| `VARNISH_BACKEND_CONNECT_TIMEOUT`       | `5s`          |                   |
+| `VARNISH_BACKEND_BETWEEN_BYTES_TIMEOUT` | `2s`          |                   |
+| `VARNISH_SECONDARY_STORAGE_CONDITION`   |               | Must be valid vcl |
 
 `VARNISH_EXCLUDE_URLS` (backslashes must be escaped `\\`):
 
@@ -45,6 +46,19 @@ See more at [wodby/varnish](https://github.com/wodby/varnish)
 ```
 pdf|asc|dat|txt|doc|xls|ppt|tgz|csv|png|gif|jpeg|jpg|ico|swf|css|js|svg
 ```
+
+`VARNISH_SECONDARY_STORAGE_CONDITION`
+
+Allows defining custom conditions for storing the cache object in the secondary 
+storage; as it is injected into an `if` it has to contain valid VCL syntax for it.
+
+Please note that `VARNISHD_SECONDARY_STORAGE` _(from the [base image](https://github.com/wodby/varnish))_
+ must be defined as well, otherwise the secondary storage would not be available.
+
+**Example:** instruct varnish to store in the secondary storage from the backend
+via custom header `X-Cache-Bin`:
+
+`VARNISH_STORAGE_CONDITION='beresp.http.x-cache-bin = "secondary"'`
 
 ## Orchestration actions
 


### PR DESCRIPTION
This addition adds a variable `VARNISH_STORAGE_CONDITION` which allows the user to specify a custom condition for switching to the secondary storage.

Examples:

- One could switch to the secondary storage for large responses:
```
    VARNISH_STORAGE_CONDITION='std.integer(beresp.http.content-length, 0) > 10240'
```

- Or based on a custom header from the backend:
```
    VARNISH_STORAGE_CONDITION='beresp.http.x-cache-bin = "secondary"'
```